### PR TITLE
6-hide-biometrics-setting-when-passwordprotect-flag-is-false

### DIFF
--- a/app/navigation/SettingsNavigation/SettingsNavigation.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.tsx
@@ -113,7 +113,9 @@ function Settings({ navigation }: SettingsProps): React.ReactElement {
     <>
       <NavHeader title="Settings" />
       <ScrollView contentContainerStyle={styles.settingsContainer}>
-        <SettingsItem title="Use biometrics to unlock" onPress={onToggleBiometrics} rightComponent={biometricSwitch} disabled={!isBiometricsSupported} />
+        {(isBiometricsSupported && FEATURE_FLAGS.passwordProtect) && (
+          <SettingsItem title="Use biometrics to unlock" onPress={onToggleBiometrics} rightComponent={biometricSwitch} />
+        )}
         <SettingsItem title="Dark mode" onPress={toggleTheme} rightComponent={themeSwitch} />
         <SettingsItem title="Manage profiles" onPress={() => navigation.navigate('ManageProfilesScreen')} />
         <SettingsItem title="Register wallet" onPress={registerWallet} />


### PR DESCRIPTION

- Modified the Settings component to display the "Use biometrics to unlock" setting only if biometrics are supported and the password protection feature flag is enabled.